### PR TITLE
Legacy to Beta End to End Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ typings/
 
 # editors, tools and IDEs
 .tern-port
+.idea/
 
 # Cypress
 cypress/videos


### PR DESCRIPTION
Key findings
- Cypress does not allow you to visit more than one domain in a single test (sub domains are ok). This is for security reasons (see https://docs.cypress.io/guides/guides/web-security.html#Cross-Origin-Iframes). This is why I am having to make a 'cy.request' to Find Beta rather than visit find. Unfortunately this also means I have to verify the payload using regex :-(
- I did try to separate the tests so that cypress could 'visit' find rather than 'request'. However ran into a weird issue where by the date object (used as an identifier in the dataset title) was mutating (or being re-instantiated) between tests
- Need to make a decision about what happens to test data after the test is run. Do we wipe the db/ index at the end?
